### PR TITLE
New Release: 1.23.1 - 2023-12-01 - Black Brook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project is versioned following the [major release].[last 2 digits in release year].[minor release] format.
+
+## [1.23.1] - 2023-12-01 - Black Brook
+
+### Added
+
+- Add missing load/save convenience functions for table views
+- Improve show() functions to allow for more flexibility + return URL
+- Add some missing convenience properties on Column and Row
+- Add function to compact a table + docs
+
+### Fixed
+
+- Fix row move/copy bug on empty cells
+- Tidy up and fix some CSS issues
+
+### Changed
+
+- Documentation improvements
+- Remove println in UI.kt and replace with logging
+- Clean up and split into CellUtils.kt from TableUtils.kt
+
+### Removed
+
+- Nothing
+
+## [1.23.0] - 2023-11-22 - First release
+
+First release

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,1 +1,2 @@
 1.23.0	2023-11-22	First Release
+1.23.1	2023-12-01	Black Brook

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = "sigbla.app"
-    version = "1.23.1-SNAPSHOT"
+    version = "1.23.1"
 
     ext {
         set("klaxonVersion", "5.6")


### PR DESCRIPTION
# Changelog

## [1.23.1] - 2023-12-01 - Black Brook

### Added

- Add missing load/save convenience functions for table views
- Improve show() functions to allow for more flexibility + return URL
- Add some missing convenience properties on Column and Row
- Add function to compact a table + docs

### Fixed

- Fix row move/copy bug on empty cells
- Tidy up and fix some CSS issues

### Changed

- Documentation improvements
- Remove println in UI.kt and replace with logging
- Clean up and split into CellUtils.kt from TableUtils.kt

### Removed

- Nothing
